### PR TITLE
Inicia widgets de controle do modelo

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -15,6 +15,17 @@ COLUMNS = {
     "C": "Hospitalizações Acumuladas",
 }
 
+DESCRPTION = {
+    "chi": "Descrição chi",
+    "phi": "Descrição phi",
+    "beta": "Descrição beta",
+    "rho": "Descrição rho",
+    "delta": "Descrição delta",
+    "alpha": "Descrição alpha",
+    "p": "Descrição p",
+    "q": "Descrição q",
+}
+
 
 def main():
     page = st.sidebar.selectbox("Escolha um Painel", ["Home",  "Modelos", "Dados"])
@@ -24,14 +35,23 @@ def main():
     elif page == 'Modelos':
         st.title("Explore a dinâmica da COVID-19")
         st.sidebar.markdown("### Parâmetros do modelo")
-        chi = st.sidebar.slider('chi', 0.0, 1.0, 0.3)
-        phi = st.sidebar.slider('phi', 0.0, 0.5, 0.01)
-        beta = st.sidebar.slider('beta', 0.0, 1.0, 0.5)
-        rho = st.sidebar.slider('rho', 0.0, 1.0, 1.0)
-        delta  = st.sidebar.slider('delta', 0.0, 1.0, 0.01)
-        alpha  = st.sidebar.slider('alpha', 0.0, 10.0, 2.0)
-        p  = st.slider('p', 0.0, 1.0, 0.75)
-        q  = st.slider('q', 0, 120, 30)
+        st.sidebar.markdown(f"<p>&chi;<span style='color:#b2b2b2;'> {DESCRPTION['chi']}</span></p>", unsafe_allow_html=True)
+        chi = st.sidebar.slider('', 0.0, 1.0, 0.3)
+        st.sidebar.markdown(f"<p>&phi;<span style='color:#b2b2b2;'> {DESCRPTION['phi']}</span></p>", unsafe_allow_html=True)
+        phi = st.sidebar.slider('', 0.0, 0.5, 0.01)
+        st.sidebar.markdown(f"<p>&beta;<span style='color:#b2b2b2;'> {DESCRPTION['beta']}</span></p>", unsafe_allow_html=True)
+        beta = st.sidebar.slider('', 0.0, 1.0, 0.5)
+        st.sidebar.markdown(f"<p>&rho;<span style='color:#b2b2b2;'> {DESCRPTION['rho']}</span></p>", unsafe_allow_html=True)
+        rho = st.sidebar.slider('', 0.0, 1.0, 1.0)
+        st.sidebar.markdown(f"<p>&delta;<span style='color:#b2b2b2;'> {DESCRPTION['delta']}</span></p>", unsafe_allow_html=True)
+        delta  = st.sidebar.slider('', 0.0, 1.0, 0.01)
+        st.sidebar.markdown(f"<p>&alpha;<span style='color:#b2b2b2;'> {DESCRPTION['alpha']}</span></p>", unsafe_allow_html=True)
+        alpha  = st.sidebar.slider('', 0.0, 10.0, 2.0)
+
+        st.markdown(f"<p>p<span style='color:#b2b2b2;'> {DESCRPTION['p']}</span></p>", unsafe_allow_html=True)
+        p  = st.slider('', 0.0, 1.0, 0.75)
+        st.markdown(f"<p>q<span style='color:#b2b2b2;'> {DESCRPTION['q']}</span></p>", unsafe_allow_html=True)
+        q  = st.slider('', 0, 120, 30)
         params = {
             'chi': chi,
             'phi': phi,

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -4,6 +4,18 @@ import numpy as np
 from epimodels.continuous.models import SEQIAHR
 st.title('Cenarios de Controle da Covid-19')
 
+
+COLUMNS = {
+    "A": "Asintomáticos",
+    "S": "Suscetíveis",
+    "E": "Expostos",
+    "I": "Infectados",
+    "H": "Hospitalizados",
+    "R": "Recuperados",
+    "C": "Hospitalizações Acumuladas",
+}
+
+
 def main():
     page = st.sidebar.selectbox("Escolha um Painel", ["Home",  "Modelos", "Dados"])
     if page == "Home":
@@ -30,7 +42,7 @@ def main():
             'p': p,
             'q': q
         }
-        traces = pd.DataFrame(data=run_model(params=params))
+        traces = pd.DataFrame(data=run_model(params=params)).rename(columns=COLUMNS)
         traces.set_index('time', inplace=True)
 
         st.line_chart(traces, height=400)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -11,25 +11,37 @@ def main():
         st.write("Escolha um painel à esquerda")
     elif page == 'Modelos':
         st.title("Explore a dinâmica da COVID-19")
-        traces = pd.DataFrame(data=run_model())
+        st.sidebar.markdown("### Parâmetros do modelo")
+        chi = st.sidebar.slider('chi', 0.0, 1.0, 0.3)
+        phi = st.sidebar.slider('phi', 0.0, 0.5, 0.01)
+        beta = st.sidebar.slider('beta', 0.0, 1.0, 0.5)
+        rho = st.sidebar.slider('rho', 0.0, 1.0, 1.0)
+        delta  = st.sidebar.slider('delta', 0.0, 1.0, 0.01)
+        alpha  = st.sidebar.slider('alpha', 0.0, 10.0, 2.0)
+        p  = st.slider('p', 0.0, 1.0, 0.75)
+        q  = st.slider('q', 0, 120, 30)
+        params = {
+            'chi': chi,
+            'phi': phi,
+            'beta': beta,
+            'rho': rho,
+            'delta': delta,
+            'alpha': alpha,
+            'p': p,
+            'q': q
+        }
+        traces = pd.DataFrame(data=run_model(params=params))
         traces.set_index('time', inplace=True)
 
-        st.line_chart(traces)
+        st.line_chart(traces, height=400)
     elif page == "Dados":
         pass
 
 
 @st.cache
-def run_model(inits=[97.3e6, 0, 1, 0, 0, 0, 0], trange=[0, 365], N=97.3e6,
-              params={'chi': .3, 'phi': .01, 'beta': .5,
-                      'rho': 1, 'delta': .1, 'alpha': 2,
-                      'p': .75, 'q': 30
-                      }):
+def run_model(inits=[97.3e6, 0, 1, 0, 0, 0, 0], trange=[0, 365], N=97.3e6, params=None):
     model = SEQIAHR()
-    model(inits=inits, trange=trange, totpop=N, params={'chi': .3, 'phi': .01, 'beta': .5,
-                                                        'rho': 1, 'delta': .1, 'alpha': 2,
-                                                        'p': .75, 'q': 30
-                                                        })
+    model(inits=inits, trange=trange, totpop=N, params=params)
     return model.traces
 
 


### PR DESCRIPTION
Oi @fccoelho Adicionei os Widgets para controle dos parâmetros do modelo.

Coloquei os parâmetros com as letras gregas na `sidebar` e o `p` e`q` acima do Gráfico. Me parece que assim ficou menos poluído. Não sei dizer se existe uma forma de termos mais controle da posição dos elementos da tela.

Voce pode me dizer o que são cada linha do gráfico? Assim altero a legenda:

![image](https://user-images.githubusercontent.com/2186646/78700327-9a4b0480-78db-11ea-8b57-eecf6812cc5e.png)

Uma coisa que poderia ficar legal é um tooltip ou "explicação" de cada parâmetro. Ex.: `p`  é a fração assintomática etc